### PR TITLE
Make WebSocket support optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-web-client"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "async web client helpers"
 license = "Apache-2.0 OR MIT"
@@ -25,7 +25,7 @@ wasm-bindgen-futures = "0.4.34"
 async-http-codec = "0.8.0"
 async-net = "1.7.0"
 futures-rustls = "0.25.0"
-async-ws = "0.4.0"
+async-ws = { version = "0.4.0", optional = true }
 webpki-roots = "0.25.1"
 rustls = "0.22"
 
@@ -37,3 +37,10 @@ console_log = { version = "1", features = ["color"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 smol = "1.3.0"
 env_logger = "0.10"
+
+[features]
+websocket = ["async-ws"]
+
+[[example]]
+name = "websocket"
+required-features = ["websocket"]

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -4,10 +4,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use async_http_codec::BodyDecodeState;
 use futures::{future::FusedFuture, ready, AsyncRead, Future};
-
-use crate::Transport;
 
 pub use self::error::HttpError;
 
@@ -68,8 +65,9 @@ pub struct ResponseRead {
     inner: ResponseReadInner,
 }
 
+#[cfg(feature = "websocket")]
 impl ResponseRead {
-    pub(crate) fn into_inner(self) -> Result<(BodyDecodeState, Transport), HttpError> {
+    pub(crate) fn into_inner(self) -> Result<(async_http_codec::BodyDecodeState, crate::Transport), HttpError> {
         self.inner.into_inner()
     }
 }

--- a/src/http/response_native.rs
+++ b/src/http/response_native.rs
@@ -29,6 +29,7 @@ impl ResponseRead {
             error: None,
         })
     }
+    #[cfg(feature = "websocket")]
     pub(crate) fn into_inner(self) -> Result<(BodyDecodeState, Transport), HttpError> {
         let ResponseRead { state, transport, error } = self;
         if let Some(err) = error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod http;
+#[cfg(feature = "websocket")]
 mod ws;
 
 use std::{
@@ -18,6 +19,7 @@ use futures_rustls::{
     TlsConnector,
 };
 use rustls_pki_types::{InvalidDnsNameError, ServerName, TrustAnchor};
+#[cfg(feature = "websocket")]
 pub use ws::*;
 
 pub enum Transport {


### PR DESCRIPTION
Introduce a new flag `websocket` gating WebSocket support, to avoid the
`async-ws` dependency in crates that don't need it.
