### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ wasm-bindgen-futures = "0.4.34"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-http-codec = "0.8.0"
-async-net = "1.7.0"
+async-net = "2.0.0"
 futures-rustls = "0.25.0"
 async-ws = { version = "0.4.0", optional = true }
 webpki-roots = "0.26.0"
@@ -35,7 +35,7 @@ console_error_panic_hook = "0.1.7"
 console_log = { version = "1", features = ["color"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-smol = "1.3.0"
+smol = "2.0.0"
 env_logger = "0.10"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ async-http-codec = "0.8.0"
 async-net = "1.7.0"
 futures-rustls = "0.25.0"
 async-ws = { version = "0.4.0", optional = true }
-webpki-roots = "0.25.1"
+webpki-roots = "0.26.0"
 rustls = "0.22"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,14 @@ lazy_static::lazy_static! {
     pub (crate) static ref DEFAULT_CLIENT_CONFIG: Arc<ClientConfig> = {
         let roots = webpki_roots::TLS_SERVER_ROOTS
         .iter()
-        .map(|t| {TrustAnchor{subject: t.subject.into(), subject_public_key_info: t.spki.into() , name_constraints: t.name_constraints.map(Into::into)}});
+        .map(|t| {
+            let t = t.to_owned();
+            TrustAnchor {
+                subject: t.subject.into(),
+                subject_public_key_info: t.subject_public_key_info.into(),
+                name_constraints: t.name_constraints.map(Into::into),
+            }
+        });
         let mut root_store = RootCertStore::empty();
         root_store.extend(roots);
         let config = ClientConfig::builder()


### PR DESCRIPTION
Upgrade dependencies to current versions, to avoid duplicate dependencies in users of async-web-client.

- Upgrade webpki-roots
- Upgrade async-net and smol
