### PR TITLE
Support using alternative rustls backends like aws-lc-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ wasm-bindgen-futures = "0.4.34"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-http-codec = "0.8.0"
-async-net = "1.7.0"
+async-net = "2.0.0"
 futures-rustls = "0.25.0"
 async-ws = { version = "0.4.0", optional = true }
 webpki-roots = "0.26.0"
@@ -35,7 +35,7 @@ console_error_panic_hook = "0.1.7"
 console_log = { version = "1", features = ["color"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-smol = "1.3.0"
+smol = "2.0.0"
 env_logger = "0.10"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ wasm-bindgen-futures = "0.4.34"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-http-codec = "0.8.0"
 async-net = "2.0.0"
-futures-rustls = "0.25.0"
+futures-rustls = { version = "0.25.1", default-features = false }
 async-ws = { version = "0.4.0", optional = true }
 webpki-roots = "0.26.0"
 
@@ -38,7 +38,14 @@ smol = "2.0.0"
 env_logger = "0.10"
 
 [features]
+default = ["ring"]
+ring = ["futures-rustls/ring"]
+aws-lc-rs = ["futures-rustls/aws-lc-rs"]
 websocket = ["async-ws"]
+
+[[example]]
+name = "post"
+required-features = ["default"]
 
 [[example]]
 name = "websocket"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ async-http-codec = "0.8.0"
 async-net = "1.7.0"
 futures-rustls = "0.25.0"
 async-ws = { version = "0.4.0", optional = true }
-webpki-roots = "0.25.1"
+webpki-roots = "0.26.0"
 rustls = "0.22"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-web-client"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "async web client helpers"
 license = "Apache-2.0 OR MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ async-net = "2.0.0"
 futures-rustls = "0.25.0"
 async-ws = { version = "0.4.0", optional = true }
 webpki-roots = "0.26.0"
-rustls = "0.22"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-logger = "0.2.0"

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -40,7 +40,7 @@ impl RequestSend<'_> {
         }
     }
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn new_with_client_config(request: &http::Request<impl AsRef<[u8]>>, client_config: std::sync::Arc<rustls::ClientConfig>) -> RequestSend<'_> {
+    pub fn new_with_client_config(request: &http::Request<impl AsRef<[u8]>>, client_config: std::sync::Arc<crate::ClientConfig>) -> RequestSend<'_> {
         let inner = request_native::RequestSend::new_with_client_config(request, client_config);
         RequestSend { inner }
     }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -30,6 +30,7 @@ pub struct RequestSend<'a> {
 }
 
 impl RequestSend<'_> {
+    #[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
     pub fn new(request: &http::Request<impl AsRef<[u8]>>) -> RequestSend<'_> {
         #[cfg(target_arch = "wasm32")]
         todo!();

--- a/src/http/request_native.rs
+++ b/src/http/request_native.rs
@@ -15,7 +15,7 @@ use futures::{AsyncWrite, Future};
 use http::uri::{PathAndQuery, Scheme};
 use http::{HeaderMap, HeaderValue, Method, Response, Uri, Version};
 
-use crate::{ClientConfig, Transport, TransportError, DEFAULT_CLIENT_CONFIG};
+use crate::{ClientConfig, Transport, TransportError};
 
 use super::common::extract_origin;
 use super::error::HttpError;
@@ -58,8 +58,9 @@ pub(crate) enum RequestSend<'a> {
 }
 
 impl RequestSend<'_> {
+    #[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
     pub fn new(request: &http::Request<impl AsRef<[u8]>>) -> RequestSend<'_> {
-        Self::new_with_client_config(request, DEFAULT_CLIENT_CONFIG.clone())
+        Self::new_with_client_config(request, crate::DEFAULT_CLIENT_CONFIG.clone())
     }
     pub fn new_with_client_config(request: &http::Request<impl AsRef<[u8]>>, client_config: Arc<ClientConfig>) -> RequestSend<'_> {
         let body = request.body().as_ref();

--- a/src/http/request_native.rs
+++ b/src/http/request_native.rs
@@ -14,9 +14,8 @@ use futures::{AsyncWrite, Future};
 
 use http::uri::{PathAndQuery, Scheme};
 use http::{HeaderMap, HeaderValue, Method, Response, Uri, Version};
-use rustls::ClientConfig;
 
-use crate::{Transport, TransportError, DEFAULT_CLIENT_CONFIG};
+use crate::{ClientConfig, Transport, TransportError, DEFAULT_CLIENT_CONFIG};
 
 use super::common::extract_origin;
 use super::error::HttpError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,14 @@ lazy_static::lazy_static! {
     pub (crate) static ref DEFAULT_CLIENT_CONFIG: Arc<ClientConfig> = {
         let roots = webpki_roots::TLS_SERVER_ROOTS
         .iter()
-        .map(|t| {TrustAnchor{subject: t.subject.into(), subject_public_key_info: t.spki.into() , name_constraints: t.name_constraints.map(Into::into)}});
+        .map(|t| {
+            let t = t.to_owned();
+            TrustAnchor {
+                subject: t.subject.into(),
+                subject_public_key_info: t.subject_public_key_info.into(),
+                name_constraints: t.name_constraints.map(Into::into),
+            }
+        });
         let mut root_store = RootCertStore::empty();
         root_store.extend(roots);
         let config = ClientConfig::builder()


### PR DESCRIPTION
Support using alternative rustls backends like aws-lc-rs

rustls has support for alternate backends, with built-in support for
aws-lc-rs, as well as support for custom user-provided backends.

Add a default-enabled feature for the default ring backend, and a
non-default feature for the aws-lc-rs backend. Also support building
without either backend, in which case we require the user to supply
their own `ClientConfig` and don't provide functions that assume a
default.


This PR builds on https://github.com/FlorianUekermann/async-web-client/pull/4
to avoid conflicts.
