### PR TITLE
10 remove clone or move body requirement

### DIFF
--- a/src/http/body.rs
+++ b/src/http/body.rs
@@ -73,6 +73,10 @@ mod tests {
     use http::Request;
 
     #[test]
+    fn test_send_with_async_read_body() {
+        Request::post("http://postman-echo.com/post").body((&[3u8] as &[u8],1)).unwrap().send();
+    }
+    #[test]
     fn test_send_with_as_ref() {
         Request::post("http://postman-echo.com/post").body(()).unwrap().send(&[3u8]);
         Request::post("http://postman-echo.com/post").body(&[3u8]).unwrap().send();

--- a/src/http/body.rs
+++ b/src/http/body.rs
@@ -74,7 +74,8 @@ mod tests {
 
     #[test]
     fn test_send_with_async_read_body() {
-        Request::post("http://postman-echo.com/post").body((&[3u8] as &[u8],1)).unwrap().send();
+        Request::post("http://postman-echo.com/post").body((futures::io::Cursor::new(&[3u8]),1)).unwrap().send();
+        Request::post("http://postman-echo.com/post").body(()).unwrap().send((futures::io::Cursor::new(&[3u8]),1));
     }
     #[test]
     fn test_send_with_as_ref() {

--- a/src/http/body.rs
+++ b/src/http/body.rs
@@ -10,9 +10,17 @@ pub trait IntoRequestBody {
 pub trait IntoNonUnitRequestBody: IntoRequestBody {}
 
 impl<'a, T: AsRef<[u8]>> IntoNonUnitRequestBody for &'a T {}
+impl<'a, T: AsyncRead> IntoNonUnitRequestBody for (T, u64) {}
 impl IntoNonUnitRequestBody for Vec<u8> {}
 impl IntoNonUnitRequestBody for String {}
 impl<T: IntoNonUnitRequestBody> IntoNonUnitRequestBody for Option<T> {}
+
+impl<'a, T: AsyncRead> IntoRequestBody for (T, u64) {
+    type RequestBody = T;
+    fn into_request_body(self) -> (Self::RequestBody, u64) {
+        (self.0, self.1)
+    }
+}
 
 impl<'a, T: AsRef<[u8]>> IntoRequestBody for &'a T {
     type RequestBody = &'a [u8];


### PR DESCRIPTION
Solves Issue 10:

- `Request<T>` is consumed when using `RequestExt::send`
- `RequestExt for Request<T>` implements `swap_body`to extract and replace `body` from `Request<T>`